### PR TITLE
Add constructor without version argument to VL pipeline classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.viaversion:viaversion-common:5.0.2-SNAPSHOT"
-    compileOnly "com.viaversion:viabackwards-common:5.0.1"
+    compileOnly "com.viaversion:viaversion-common:5.0.2"
+    compileOnly "com.viaversion:viabackwards-common:5.0.2"
     compileOnly "com.viaversion:viarewind-common:4.0.0"
     compileOnly "net.raphimc:ViaLegacy:3.0.1"
     compileOnly "net.raphimc:viaaprilfools-common:3.0.1-SNAPSHOT"

--- a/src/main/java/net/raphimc/vialoader/netty/VLLegacyPipeline.java
+++ b/src/main/java/net/raphimc/vialoader/netty/VLLegacyPipeline.java
@@ -17,8 +17,10 @@
  */
 package net.raphimc.vialoader.netty;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.api.protocol.version.VersionType;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -47,6 +49,11 @@ public abstract class VLLegacyPipeline extends ChannelInboundHandlerAdapter {
     protected final UserConnection user;
     protected final ProtocolVersion version;
 
+    public VLLegacyPipeline(final UserConnection user) {
+        this(user, Via.getManager().getProviders().get(VersionProvider.class).getServerProtocol(user));
+    }
+
+    @Deprecated
     public VLLegacyPipeline(final UserConnection user, final ProtocolVersion version) {
         this.user = user;
         this.version = version;
@@ -57,6 +64,9 @@ public abstract class VLLegacyPipeline extends ChannelInboundHandlerAdapter {
         ctx.pipeline().addBefore(this.packetDecoderName(), VIA_DECODER_NAME, this.createViaDecoder());
         ctx.pipeline().addBefore(this.packetEncoderName(), VIA_ENCODER_NAME, this.createViaEncoder());
 
+        if (this.version == null) {
+            return;
+        }
         final ProtocolVersion r1_6_4 = ProtocolVersion.getProtocol(VersionType.RELEASE_INITIAL, 78);
         if (r1_6_4.isKnown() && this.version.olderThanOrEqualTo(r1_6_4)) {
             this.user.getProtocolInfo().getPipeline().add(PreNettyBaseProtocol.INSTANCE);

--- a/src/main/java/net/raphimc/vialoader/netty/VLLegacyPipeline.java
+++ b/src/main/java/net/raphimc/vialoader/netty/VLLegacyPipeline.java
@@ -64,9 +64,6 @@ public abstract class VLLegacyPipeline extends ChannelInboundHandlerAdapter {
         ctx.pipeline().addBefore(this.packetDecoderName(), VIA_DECODER_NAME, this.createViaDecoder());
         ctx.pipeline().addBefore(this.packetEncoderName(), VIA_ENCODER_NAME, this.createViaEncoder());
 
-        if (this.version == null) {
-            return;
-        }
         final ProtocolVersion r1_6_4 = ProtocolVersion.getProtocol(VersionType.RELEASE_INITIAL, 78);
         if (r1_6_4.isKnown() && this.version.olderThanOrEqualTo(r1_6_4)) {
             this.user.getProtocolInfo().getPipeline().add(PreNettyBaseProtocol.INSTANCE);

--- a/src/main/java/net/raphimc/vialoader/netty/VLPipeline.java
+++ b/src/main/java/net/raphimc/vialoader/netty/VLPipeline.java
@@ -17,8 +17,10 @@
  */
 package net.raphimc.vialoader.netty;
 
+import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.api.protocol.version.VersionType;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -45,6 +47,11 @@ public abstract class VLPipeline extends ChannelInboundHandlerAdapter {
     protected final UserConnection user;
     protected final ProtocolVersion version;
 
+    public VLPipeline(final UserConnection user) {
+        this(user, Via.getManager().getProviders().get(VersionProvider.class).getServerProtocol(user));
+    }
+
+    @Deprecated
     public VLPipeline(final UserConnection user, final ProtocolVersion version) {
         this.user = user;
         this.version = version;
@@ -54,6 +61,9 @@ public abstract class VLPipeline extends ChannelInboundHandlerAdapter {
     public void handlerAdded(ChannelHandlerContext ctx) {
         ctx.pipeline().addBefore(this.packetCodecName(), VIA_CODEC_NAME, this.createViaCodec());
 
+        if (this.version == null) {
+            return;
+        }
         final ProtocolVersion r1_6_4 = ProtocolVersion.getProtocol(VersionType.RELEASE_INITIAL, 78);
         if (r1_6_4.isKnown() && this.version.olderThanOrEqualTo(r1_6_4)) {
             this.user.getProtocolInfo().getPipeline().add(PreNettyBaseProtocol.INSTANCE);

--- a/src/main/java/net/raphimc/vialoader/netty/VLPipeline.java
+++ b/src/main/java/net/raphimc/vialoader/netty/VLPipeline.java
@@ -61,9 +61,6 @@ public abstract class VLPipeline extends ChannelInboundHandlerAdapter {
     public void handlerAdded(ChannelHandlerContext ctx) {
         ctx.pipeline().addBefore(this.packetCodecName(), VIA_CODEC_NAME, this.createViaCodec());
 
-        if (this.version == null) {
-            return;
-        }
         final ProtocolVersion r1_6_4 = ProtocolVersion.getProtocol(VersionType.RELEASE_INITIAL, 78);
         if (r1_6_4.isKnown() && this.version.olderThanOrEqualTo(r1_6_4)) {
             this.user.getProtocolInfo().getPipeline().add(PreNettyBaseProtocol.INSTANCE);


### PR DESCRIPTION
Never needed since we could have called the version provider which should be used to get both client and server version.